### PR TITLE
[Backend] As a User, my uploaded keywords should be processed immediately

### DIFF
--- a/app/jobs/scrape_keyword_job.rb
+++ b/app/jobs/scrape_keyword_job.rb
@@ -16,6 +16,6 @@ class ScrapeKeywordJob < ApplicationJob
   def perform(keyword_id:)
     Google::ScrapeService.new(keyword_id: keyword_id).call!
   rescue GoogleScraperRuby::Errors::ScrapeError => error
-    raise error unless error.kind == :invalid_keyword
+    raise(error) unless error.kind == :invalid_keyword
   end
 end

--- a/app/jobs/scrape_keyword_job.rb
+++ b/app/jobs/scrape_keyword_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ScrapeKeywordJob < ApplicationJob
+  queue_as :default
+
+  sidekiq_options retry: 0
+
+  retry_on GoogleScraperRuby::Errors::ScrapeError, wait: 1.minute, attempts: 3 do |job, _error|
+    keyword_id = job.arguments.first[:keyword_id]
+    # TODO(Goose97): better handle database failure
+    # If the below update crashes, the system ends up in an inconsistent state: the job still
+    # has :processing status but already moved to Sidekiq dead queue
+    Keyword.update(keyword_id, status: :failed)
+  end
+
+  def perform(keyword_id:)
+    Google::ScrapeService.new(keyword_id: keyword_id).call!
+  rescue GoogleScraperRuby::Errors::ScrapeError => error
+    raise error unless error.kind == :invalid_keyword
+  end
+end

--- a/app/lib/google_scraper_ruby/errors/scrape_error.rb
+++ b/app/lib/google_scraper_ruby/errors/scrape_error.rb
@@ -3,6 +3,8 @@
 module GoogleScraperRuby
   module Errors
     class ScrapeError < StandardError
+      attr_reader :kind
+
       def initialize(keyword_id:, kind:, error: nil)
         @keyword_id = keyword_id
         @kind = kind
@@ -21,7 +23,7 @@ module GoogleScraperRuby
 
       private
 
-      attr_reader :keyword_id, :kind, :original_error
+      attr_reader :keyword_id, :original_error
     end
   end
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -11,4 +11,10 @@ class Keyword < ApplicationRecord
             presence: true,
             numericality: { greater_than_or_equal_to: 0 },
             if: :succeeded?
+
+  after_create_commit :enqueue_scrape_job
+
+  def enqueue_scrape_job
+    ScrapeKeywordJob.perform_later keyword_id: id
+  end
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -15,8 +15,8 @@ class Keyword < ApplicationRecord
   after_create_commit :enqueue_scrape_job
 
   private
-  
+
   def enqueue_scrape_job
-    ScrapeKeywordJob.perform_later keyword_id: id
+    ScrapeKeywordJob.perform_later(keyword_id: id)
   end
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -14,6 +14,8 @@ class Keyword < ApplicationRecord
 
   after_create_commit :enqueue_scrape_job
 
+  private
+  
   def enqueue_scrape_job
     ScrapeKeywordJob.perform_later keyword_id: id
   end

--- a/app/services/google/scrape_service.rb
+++ b/app/services/google/scrape_service.rb
@@ -9,9 +9,9 @@ module Google
     end
 
     def call!
-      # TODO(Goose97): update failed status once we integrate with background job
       begin
         @keyword = Keyword.find(keyword_id)
+        keyword.update(status: :processing)
       rescue ActiveRecord::RecordNotFound
         raise_keyword_not_found
       end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -16,12 +16,12 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.
@@ -78,4 +78,6 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missing.
   config.assets.compile = false
+
+  ActiveJob::Base.queue_adapter = :test
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,10 @@
 ---
 :concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || 4 %>
+:logfile: ./log/sidekiq.log
 :queues:
   - [default, 1]
+  - [development_default, 1]
+  - [production_default, 1]
   - [mailers, 2]
+  - [development_mailers, 2]
+  - [production_mailers, 2]

--- a/spec/forms/csv_upload_form_spec.rb
+++ b/spec/forms/csv_upload_form_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe(CsvUploadForm, type: :form) do
         end.to(change(Keyword, :count).by(7))
       end
 
+      it 'enqueues a ScrapeKeywordJob for each keyword' do
+        ActiveJob::Base.queue_adapter = :test
+        form = described_class.new
+        file = FileUploadHelpers::Form.upload_file(fixture: 'valid_7_keywords.csv')
+
+        form.save(file)
+
+        # It would be better if we can assert that keyword_id also matches
+        expect(ScrapeKeywordJob).to(have_been_enqueued.exactly(7))
+      end
+
       context 'given keywords contain commas' do
         it 'includes commas in the parsed result' do
           form = described_class.new

--- a/spec/jobs/scrape_keyword_job_spec.rb
+++ b/spec/jobs/scrape_keyword_job_spec.rb
@@ -13,7 +13,7 @@ describe ScrapeKeywordJob do
             described_class.perform_later(keyword_id: 42)
           end
 
-          assert_performed_jobs 1
+          assert_performed_jobs(1)
         end
       end
 
@@ -29,7 +29,7 @@ describe ScrapeKeywordJob do
 
           perform_enqueued_jobs { described_class.perform_later(keyword_id: keyword.id) }
 
-          assert_performed_jobs 3
+          assert_performed_jobs(3)
         end
 
         context 'when the maximum retry times is exceeded' do

--- a/spec/jobs/scrape_keyword_job_spec.rb
+++ b/spec/jobs/scrape_keyword_job_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ScrapeKeywordJob do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    context 'given an ERROR occurs' do
+      context "when the keyword doesn't exist" do
+        it 'DOES NOT retry' do
+          perform_enqueued_jobs do
+            described_class.perform_later(keyword_id: 42)
+          end
+
+          assert_performed_jobs 1
+        end
+      end
+
+      context 'when an unexpected error occurs' do
+        it 'retries at most 3 times' do
+          keyword = Fabricate :keyword
+
+          stub = Google::ScrapeService.new(keyword_id: keyword.id)
+          allow(stub).to receive(:call!).and_raise(
+            GoogleScraperRuby::Errors::ScrapeError.new(keyword_id: keyword.id, kind: :unexpected_error)
+          )
+          allow(Google::ScrapeService).to receive(:new).and_return(stub)
+
+          perform_enqueued_jobs { described_class.perform_later(keyword_id: keyword.id) }
+
+          assert_performed_jobs 3
+        end
+
+        context 'when the maximum retry times is exceeded' do
+          it 'sets the keyword status as :failed' do
+            keyword = Fabricate :keyword
+
+            stub = Google::ScrapeService.new(keyword_id: keyword.id)
+            allow(stub).to receive(:call!).and_raise(
+              GoogleScraperRuby::Errors::ScrapeError.new(keyword_id: keyword.id, kind: :unexpected_error)
+            )
+            allow(Google::ScrapeService).to receive(:new).and_return(stub)
+
+            perform_enqueued_jobs { described_class.perform_later(keyword_id: keyword.id) }
+            keyword.reload
+
+            expect(keyword).to be_failed
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/scrape_keyword_job_spec.rb
+++ b/spec/jobs/scrape_keyword_job_spec.rb
@@ -19,13 +19,13 @@ describe ScrapeKeywordJob do
 
       context 'when an unexpected error occurs' do
         it 'retries at most 3 times' do
-          keyword = Fabricate :keyword
+          keyword = Fabricate(:keyword)
 
           stub = Google::ScrapeService.new(keyword_id: keyword.id)
-          allow(stub).to receive(:call!).and_raise(
-            GoogleScraperRuby::Errors::ScrapeError.new(keyword_id: keyword.id, kind: :unexpected_error)
-          )
-          allow(Google::ScrapeService).to receive(:new).and_return(stub)
+          allow(stub).to(receive(:call!).and_raise(
+                           GoogleScraperRuby::Errors::ScrapeError.new(keyword_id: keyword.id, kind: :unexpected_error)
+                         ))
+          allow(Google::ScrapeService).to(receive(:new).and_return(stub))
 
           perform_enqueued_jobs { described_class.perform_later(keyword_id: keyword.id) }
 
@@ -34,18 +34,18 @@ describe ScrapeKeywordJob do
 
         context 'when the maximum retry times is exceeded' do
           it 'sets the keyword status as :failed' do
-            keyword = Fabricate :keyword
+            keyword = Fabricate(:keyword)
 
             stub = Google::ScrapeService.new(keyword_id: keyword.id)
-            allow(stub).to receive(:call!).and_raise(
-              GoogleScraperRuby::Errors::ScrapeError.new(keyword_id: keyword.id, kind: :unexpected_error)
-            )
-            allow(Google::ScrapeService).to receive(:new).and_return(stub)
+            allow(stub).to(receive(:call!).and_raise(
+                             GoogleScraperRuby::Errors::ScrapeError.new(keyword_id: keyword.id, kind: :unexpected_error)
+                           ))
+            allow(Google::ScrapeService).to(receive(:new).and_return(stub))
 
             perform_enqueued_jobs { described_class.perform_later(keyword_id: keyword.id) }
             keyword.reload
 
-            expect(keyword).to be_failed
+            expect(keyword).to(be_failed)
           end
         end
       end

--- a/spec/jobs/scrape_keyword_job_spec.rb
+++ b/spec/jobs/scrape_keyword_job_spec.rb
@@ -21,11 +21,11 @@ describe ScrapeKeywordJob do
         it 'retries at most 3 times' do
           keyword = Fabricate(:keyword)
 
-          stub = Google::ScrapeService.new(keyword_id: keyword.id)
-          allow(stub).to(receive(:call!).and_raise(
-                           GoogleScraperRuby::Errors::ScrapeError.new(keyword_id: keyword.id, kind: :unexpected_error)
-                         ))
-          allow(Google::ScrapeService).to(receive(:new).and_return(stub))
+          scrape_service = instance_double(Google::ScrapeService)
+          allow(scrape_service).to(receive(:call!).and_raise(
+                                     GoogleScraperRuby::Errors::ScrapeError.new(keyword_id: keyword.id, kind: :unexpected_error)
+                                   ))
+          allow(Google::ScrapeService).to(receive(:new).and_return(scrape_service))
 
           perform_enqueued_jobs { described_class.perform_later(keyword_id: keyword.id) }
 


### PR DESCRIPTION
[[Backend] As a User, my uploaded keywords should be processed immediately](https://github.com/Goose97/google-scraper-ruby/issues/15)

## What happened 👀

Integrate keyword scraping with background job system backed by Sidekiq

## Insight 📝

- Jobs are enqueued immediately after keywords are created via `after_create_commit` callback
- The retry mechanism is currently implemented using ActiveJob `retry_on` method. Another alternative that I've considered is using Sidekiq native retry mechanism. I chose ActiveJob because:
  - After looked up others IC, it seems like we prefer using ActiveJob
  - Handling retry times exhaustion (in this case, we set keyword status to `:failed`) with ActiveJob is more convenient. Sidekiq has an option to do that, but ActiveJob is [yet to support it](https://github.com/sidekiq/sidekiq/pull/5994)
  
~~There is one caveat when choosing ActiveJob. My hunch is that if the Ruby node is restarted when a job is processing/retrying, the job will be marked as failed and since [we disable Sidekiq retry](https://github.com/Goose97/google-scraper-ruby/blob/6ea9f10725679d8fa43749ab837bae6754cbee43/app/jobs/scrape_keyword_job.rb#L6), the job will be lost. I'm looking for documentations to confirm this. Can I have your words on this @andyduong1920 ?~~

My bad, I thought that background worker threads are run inside Rails server process. They run in Sidekiq process, so restart the server process won't affect running jobs