### PR TITLE
[API] As a User, I can upload CSV keyword files

### DIFF
--- a/app/controllers/api/v1/keywords_controller.rb
+++ b/app/controllers/api/v1/keywords_controller.rb
@@ -32,11 +32,30 @@ module Api
         render(json: ::V1::SearchResultSimpleSerializer.new(result, is_collection: true))
       end
 
+      def create
+        form = CsvUploadForm.new
+
+        if form.save(create_params[:file])
+          render(
+            json: ::V1::KeywordSimpleSerializer.new(form.keywords, is_collection: true),
+            status: :created
+          )
+        else
+          render_error(status: :unprocessable_entity, code: :invalid_csv_file)
+        end
+      end
+
+      private
+
       def search_params
         {
           search: params.require(:search),
           query_type: params.require(:query_type).to_sym
         }
+      end
+
+      def create_params
+        { file: params.require(:file) }
       end
     end
   end

--- a/app/forms/csv_upload_form.rb
+++ b/app/forms/csv_upload_form.rb
@@ -7,6 +7,8 @@ class CsvUploadForm
 
   validates :file, presence: true, csv_keyword_file: true
 
+  attr_reader :keywords
+
   def save(file)
     @file = file
     return false unless valid?
@@ -14,8 +16,8 @@ class CsvUploadForm
     @keywords = parsed_keywords
     return false unless keywords_valid?
 
-    ActiveRecord::Base.transaction do
-      keywords.each do |keyword|
+    @keywords = ActiveRecord::Base.transaction do
+      keywords.map do |keyword|
         Keyword.create(content: keyword)
       end
     end
@@ -25,7 +27,7 @@ class CsvUploadForm
 
   private
 
-  attr_reader :file, :keywords
+  attr_reader :file
 
   def parsed_keywords
     CSV.read(file).filter_map do |csv_record|

--- a/app/serializers/v1/search_result_simple_serializer.rb
+++ b/app/serializers/v1/search_result_simple_serializer.rb
@@ -7,11 +7,11 @@ module V1
     end
 
     attributes :keyword_id do |record|
-      record['keyword_id']
+      record[:keyword_id]
     end
 
     attributes :urls do |record|
-      record['urls']
+      record[:urls]
     end
 
     belongs_to :keyword, lazy_load_data: true, links: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :keywords, only: %i[index show] do
+      resources :keywords, only: %i[index create show] do
         get 'search', on: :collection
       end
     end

--- a/spec/forms/csv_upload_form_spec.rb
+++ b/spec/forms/csv_upload_form_spec.rb
@@ -24,6 +24,19 @@ RSpec.describe(CsvUploadForm, type: :form) do
         end.to(change(Keyword, :count).by(7))
       end
 
+      it 'includes the created keywords in the form object' do
+        form = described_class.new
+        file = FileUploadHelpers::Form.upload_file(fixture: 'valid_7_keywords.csv')
+
+        form.save(file)
+
+        expect(form.keywords).to(all(be_a(Keyword)))
+        expect(form.keywords.map(&:content)).to(contain_exactly('ruby', 'database',
+                                                                'oolong tea', 'com tam suon bi cha',
+                                                                'marriage story', 'iphone store',
+                                                                'ruby, ruby on rails'))
+      end
+
       it 'enqueues a ScrapeKeywordJob for each keyword' do
         ActiveJob::Base.queue_adapter = :test
         form = described_class.new

--- a/spec/requests/api/v1/keywords_controller_spec.rb
+++ b/spec/requests/api/v1/keywords_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/file_upload_helpers'
 
 RSpec.describe(Api::V1::KeywordsController) do
   describe 'GET #index' do
@@ -104,6 +105,36 @@ RSpec.describe(Api::V1::KeywordsController) do
 
           expect(response).to(have_http_status(:unprocessable_entity))
         end
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context 'given a VALID file' do
+      it 'returns a 201 status code' do
+        file = FileUploadHelpers::Form.upload_file(fixture: 'valid_7_keywords.csv')
+
+        post(api_v1_keywords_path, params: { file: file })
+
+        expect(response).to(have_http_status(:created))
+      end
+
+      it 'returns the created keywords' do
+        file = FileUploadHelpers::Form.upload_file(fixture: 'valid_7_keywords.csv')
+
+        post(api_v1_keywords_path, params: { file: file })
+
+        expect(response).to(match_json_schema('v1/keywords/list'))
+      end
+    end
+
+    context 'given an INVALID file' do
+      it 'returns a 422 status code' do
+        file = FileUploadHelpers::Form.upload_file(fixture: 'too_long_keywords.csv')
+
+        post(api_v1_keywords_path, params: { file: file })
+
+        expect(response).to(have_http_status(:unprocessable_entity))
       end
     end
   end


### PR DESCRIPTION
Closes [[API] As a User, I can upload CSV keyword files](https://github.com/Goose97/google-scraper-ruby/issues/24)

## What happened 👀

Implement CSV files upload API

## Insight 📝

- [x] IMPORTANT: CsvUploadForm will now include the newly created keywords in the form object after successfully processed
- [x] Implement CSV files upload at `POST api/v1/keywords`

## Proof Of Work 📹

![image](https://github.com/Goose97/google-scraper-ruby/assets/35915460/d8e2da04-86e8-4521-95e0-fa31e6a42f59)
